### PR TITLE
Update snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -66,6 +66,7 @@ parts:
       - libpulse0
       - libxss1
       - libxtst6
+      - libx11-xcb1
   desktop-gtk3:
     build-packages:
     - build-essential


### PR DESCRIPTION
We're missing libx11-xcb1 since the migration to core18.