### PR TITLE
Handle displays using wayland

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -78,6 +78,7 @@ apps:
     # or disappear completely.
     environment:
       TMPDIR: $XDG_RUNTIME_DIR
+      DISABLE_WAYLAND: 1
       XDG_CURRENT_DESKTOP: Unity
     plugs:
       - bluez


### PR DESCRIPTION
Set environment variable DISABLE_WAYLAND to 1 to force fallback to Xwayland.

Without this, yakyak will simply not start when run from a launcher. When run from a shell one sees

```
pontus@sterna:~/Utveckling/yakyak$ yakyak 

(yakyak:5506): Gtk-WARNING **: 12:55:57.238: cannot open display: :0
pontus@sterna:~/Utveckling/yakyak$ 
```